### PR TITLE
fix(references): update reference to Rswag::Ui::BasicAuth and env_mat…

### DIFF
--- a/rswag-ui/lib/rswag/ui/basic_auth.rb
+++ b/rswag-ui/lib/rswag/ui/basic_auth.rb
@@ -9,21 +9,18 @@ module Rswag
     #
     class BasicAuth < ::Rack::Auth::Basic
       def call(env)
-        return @app.call(env) unless env_matching_path
+        return @app.call(env) unless env_matching_path(env)
 
         super(env)
       end
 
       private
 
-      def env_matching_path
-        Rswag::Ui.config.swagger_endpoints[:urls].find do |endpoint|
-          base_path(endpoint[:url]) == env_base_path
+      def env_matching_path(env)
+        path = base_path(env['PATH_INFO'])
+        Rswag::Ui.config.config_object[:urls].find do |endpoint|
+          base_path(endpoint[:url]) == path
         end
-      end
-
-      def env_base_path
-        base_path(env['PATH_INFO'])
       end
 
       def base_path(url)

--- a/rswag-ui/lib/rswag/ui/engine.rb
+++ b/rswag-ui/lib/rswag/ui/engine.rb
@@ -11,7 +11,7 @@ module Rswag
 
         if Rswag::Ui.config.basic_auth_enabled
           c = Rswag::Ui.config
-          app.middleware.use UiBasicAuth do |username, password|
+          app.middleware.use Rswag::Ui::BasicAuth do |username, password|
             c.config_object[:basic_auth].values == [username, password]
           end
         end


### PR DESCRIPTION
…ching_path environment accessor

While attempting to use this fork a few issues cropped up.

## Changes
1. ENV seemed to be nil within BasicAuth, exposing it to `env_matching_path` seems to fix this.
2. The code was referencing `UiBasicAuth` which I assume was meant to be `Rswag::Ui::BasicAuth`

I am going to work through the integration of this tonight to see if any other issues pop up.
